### PR TITLE
Utilise la branche `main` du thème kabusin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.3.2"
 
 # Jekyll themes for Scribouilli
-gem "kabusin", git: "https://github.com/Scribouilli/kabusin.git", branch: "add-gemspec"
+gem "kabusin", git: "https://github.com/Scribouilli/kabusin.git", branch: "main"
 
 group :jekyll_plugins do
   # Handle redirections

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Scribouilli/kabusin.git
-  revision: 9ea8fb6fae845abe5f3dacafb2a23861cff39fd9
-  branch: add-gemspec
+  revision: 0e87c9506bac503f7bbab5be3627a691556aa602
+  branch: main
   specs:
     kabusin (1.0.0)
       jekyll (~> 4.3.2)


### PR DESCRIPTION
- [ ] Lancer `bundle` après que https://github.com/Scribouilli/kabusin/pull/1 soit mergé et committer le nouveau `Gemfile.lock`

## Description

Cette PR change la branche à partir de laquelle on veut récupérer la gem du thème kabusin.