### PR TITLE
Mise à jour de l'action upload-pages-artifact

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,7 +47,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
 
   # Deployment job
   deploy:


### PR DESCRIPTION
J'utilise un hash de commit parce que c'est un petit plusse niveau sécurité (si jamais une personne mal intentionnée prend le contrôle du dépôt de l'action, il ne pourra pas nous faire utiliser du code auquel on ne s'attend pas dans notre dos en re-créant un tag git).